### PR TITLE
[misc] Pin the version to Taichi 1.2.0 currently

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-taichi>=1.2.0
+taichi==1.2.0
 trimesh


### PR DESCRIPTION
Pin the version to Taichi 1.2.0 currently.

From Taichi 1.3.0, the dynamic examples are broken. I am investigating the problem. 