### PR TITLE
Fix pressure coefficient a_ii formula

### DIFF
--- a/IISPH.py
+++ b/IISPH.py
@@ -35,7 +35,7 @@ class IISPHSolver(SPHBase):
                 x_j = self.ps.x[p_j]
                 sum_neighbor_inner = ti.Vector([0.0 for _ in range(self.ps.dim)])
                 for k in range(self.ps.fluid_neighbors_num[p_i]):
-                    p_k = self.ps.fluid_neighbors[p_i, j]
+                    p_k = self.ps.fluid_neighbors[p_i, k]
                     x_k = self.ps.x[p_k]
                     sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_i2
 
@@ -53,7 +53,7 @@ class IISPHSolver(SPHBase):
                 x_j = self.ps.x[p_j]
                 sum_neighbor_inner = ti.Vector([0.0 for _ in range(self.ps.dim)])
                 for k in range(self.ps.solid_neighbors_num[p_i]):
-                    p_k = self.ps.solid_neighbors[p_i, j]
+                    p_k = self.ps.solid_neighbors[p_i, k]
                     x_k = self.ps.x[p_k]
                     sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_i2
 

--- a/IISPH.py
+++ b/IISPH.py
@@ -35,11 +35,9 @@ class IISPHSolver(SPHBase):
                 x_j = self.ps.x[p_j]
                 sum_neighbor_inner = ti.Vector([0.0 for _ in range(self.ps.dim)])
                 for k in range(self.ps.fluid_neighbors_num[p_i]):
-                    density_k = self.ps.density[k]
-                    density_k2 = density_k * density_k
                     p_k = self.ps.fluid_neighbors[p_i, j]
                     x_k = self.ps.x[p_k]
-                    sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_k2
+                    sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_i2
 
                 kernel_grad_ij = self.cubic_kernel_derivative(x_i - x_j)
                 sum_neighbor -= (self.ps.m_V[p_j] * sum_neighbor_inner).dot(kernel_grad_ij)
@@ -55,11 +53,9 @@ class IISPHSolver(SPHBase):
                 x_j = self.ps.x[p_j]
                 sum_neighbor_inner = ti.Vector([0.0 for _ in range(self.ps.dim)])
                 for k in range(self.ps.solid_neighbors_num[p_i]):
-                    density_k = self.ps.density[k]
-                    density_k2 = density_k * density_k
                     p_k = self.ps.solid_neighbors[p_i, j]
                     x_k = self.ps.x[p_k]
-                    sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_k2
+                    sum_neighbor_inner += self.ps.m_V[p_k] * self.cubic_kernel_derivative(x_i - x_k) / density_i2
 
                 kernel_grad_ij = self.cubic_kernel_derivative(x_i - x_j)
                 sum_neighbor -= (self.ps.m_V[p_j] * sum_neighbor_inner).dot(kernel_grad_ij)


### PR DESCRIPTION
If you look at the IISPH paper
https://cg.informatik.uni-freiburg.de/publications/2013_TVCG_IISPH.pdf at page
4, equation 9, the formula for d_ii has \rho_i^2 instead of \rho_j^2 which is
used in equation 12 to compute a_ii.

In eqn 9, the d_ij term has \rho_j^2 but since d_ji is used in equation 12, it
also gets converted to \rho_i^2. Hence the equation for a_ii only uses density
of i-th particle.